### PR TITLE
Fix: Test is a test from co-pilot (issue #3)

### DIFF
--- a/fixes/ISSUE-3.md
+++ b/fixes/ISSUE-3.md
@@ -1,0 +1,3 @@
+This is a placeholder fix for issue #3 — Test is a test from co-pilot.
+
+See https://github.com/chinua/chinaction/issues/3 for details.


### PR DESCRIPTION
This PR provides a placeholder fix for issue #3 — 'Test is a test from co-pilot'.

See the issue: https://github.com/chinua/chinaction/issues/3

The change adds `fixes/ISSUE-3.md` which references the issue.

Closes #3.